### PR TITLE
Update vllm image + fix TVM_FFI_CACHE_DIR issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Deploy a model using the CLI:
 module load python
 export HF_TOKEN=<my-token> # Required for gated models (Llama, Mistral, etc.)
 export HF_HOME=$SCRATCH/huggingface # Use SCRATCH for better performance and space
-export vLLM_IMAGE=vllm/vllm-openai:v0.10.0 # Optional: Use custom vLLM Shifter image. Make sure image is avaliable in shifterimg
+#export vLLM_IMAGE=vllm/vllm-openai:v0.10.0 # Optional: Use custom vLLM Shifter image. Make sure image is avaliable in shifterimg
 
 nersc-chat -A your_account -m meta-llama/Llama-3.1-8B-Instruct
 # Use `nersc-chat --help` for more options

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ The `nersc_chatbot_deploy` package deploys vLLM within a **Shifter container** o
 3. **vLLM Service**: Serves the model with an OpenAI-compatible API endpoint
 4. **Monitoring**: Tracks job status and service health
 
-**Default Shifter image**: `vllm/vllm-openai:v0.11.0`
+**Default Shifter image**: `vllm/vllm-openai:v0.15.0`
 
 ## NERSC Environment Setup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "gradio",
   "openai",
   "ipython",
+  "packaging",
   "rich",
 ]
 license = "Apache-2.0"


### PR DESCRIPTION
Updated the vllm to `vllm/vllm-openai:v0.15.0`.

Also added in `TVM_FFI_CACHE_DIR` to default to `$SCRATCH` as was having file locking issues.